### PR TITLE
Hide timeline connector on Processing indicator

### DIFF
--- a/app/src/styles/webview.css
+++ b/app/src/styles/webview.css
@@ -437,7 +437,8 @@ button {
 .timelineMessage.processingMessage {
   padding-left: 24px;
 }
-.timelineMessage.processingMessage:before {
+.timelineMessage.processingMessage:before,
+.timelineMessage.processingMessage:after {
   display: none;
 }
 @keyframes cmx-blink {


### PR DESCRIPTION
Closes #23

## Root cause
The `.timelineMessage:after` pseudo draws the timeline connector line. When the Processing spinner is **standalone**, a complex `:not(... + .)` `:not(:has(+ .))` rule hides it. But when the spinner appears **mid-sequence** (after a previous assistant `timelineMessage`), the first `:not` doesn't match and the `:after` stays visible — a 1px × 18px stub at `left:12px` reading as a dot beside "Processing...".

## Fix
Drop the connector explicitly on `.processingMessage:after`, matching the existing handling of `:before`.

\`\`\`css
.timelineMessage.processingMessage:before,
.timelineMessage.processingMessage:after {
  display: none;
}
\`\`\`

## Test plan
- [x] Repro: rendered the wrapper DOM with `webview.css` in headless Chromium with a preceding `timelineMessage` — `:after` shows as 1px × 18px gray vertical bar (the "dot").
- [x] After fix: `getComputedStyle` returns `display: none` for both `:before` and `:after`. Visual screenshot shows clean "Processing..." text with no leading artifact.
- [x] Standalone case (no preceding timelineMessage) — still clean (the original standalone selector still applies; this rule is now belt-and-suspenders).